### PR TITLE
Update Webstorm version and make it configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 FROM kurron/docker-azul-jdk-8-build:latest
 
+ARG VERSION=2019.3.3
+
 MAINTAINER Ron Kurr <kurr@kurron.org>
 
 ENV WEBIDE_JDK /usr/lib/jvm/zulu-8-amd64
 
-ENTRYPOINT ["/opt/WebStorm-193.5662.54/bin/webstorm.sh"]
-
 USER root
 
-ADD https://download.jetbrains.com/webstorm/WebStorm-2019.3.1.tar.gz /opt
-
-RUN tar -xzf /opt/WebStorm-2019.3.1.tar.gz -C /opt && \
-    ls -Allh /opt && \
-    rm -rf /opt/WebStorm-*/jre64 /opt/WebStorm-2019.3.1.tar.gz
+RUN mkdir /opt/webstorm \
+    && curl -L "https://download.jetbrains.com/webstorm/WebStorm-${VERSION}.tar.gz" \
+        | tar -xz --strip-components=1 -C /opt/webstorm
 
 USER powerless
+
+ENTRYPOINT ["/opt/webstorm/bin/webstorm.sh"]


### PR DESCRIPTION
* Default version: 2019.3.3
* Version can be changed with VERSION build argument
* Webstorm is now installed to /opt/webstorm